### PR TITLE
Quality-of-life improvements

### DIFF
--- a/src/StructIO.jl
+++ b/src/StructIO.jl
@@ -109,7 +109,16 @@ function unsafe_unpack(io::IO, T::Type, target, endianness, ::Type{Packed})
     end
 end
 
-function unpack(io::IO, T::Type, endianness = :NativeEndian)
+"""
+unpack(io::IO, T::Type, endianness::Symbol = :NativeEndian)
+
+Given an input `io`, unpack type `T`, byte-swapping according to the given
+`endianness` of `io`. If `endianness` is `:NativeEndian` (the default), no
+byteswapping will occur.  If `endianness` is `:LittleEndian` or `:BigEndian`,
+byteswapping will occur of the endianness of the currently running host does
+not match the endianness of `io`.
+"""
+function unpack(io::IO, T::Type, endianness::Symbol = :NativeEndian)
     r = Ref{T}()
     unsafe_unpack(io, T, r, endianness, nfields(T) == 0 ? Default : strategy(T))
     r[]

--- a/src/StructIO.jl
+++ b/src/StructIO.jl
@@ -198,7 +198,7 @@ last argument is a packing strategy, used to determine the layout of the data
 in memory.  All `Packed` objects recurse until bitstypes objects are eventually
 reached, at which point `Default` packing is identical to `Packed` behavior.
 """
-function unsafe_pack(io, source::Ref{T}, endianness, ::Type{Default}) where T
+function unsafe_pack{T}(io, source::Ref{T}, endianness, ::Type{Default})
     sz = packed_size(T)
     if !needs_bswap(endianness)
         # If we don't need to bswap, just write directly from `source`
@@ -253,7 +253,7 @@ function unsafe_unpack(io, T, target, endianness, ::Type{Packed})
 end
 
 # `Packed` packing strategy override for `unsafe_pack`
-function unsafe_pack(io, source::Ref{T}, endianness, ::Type{Packed}) where T
+function unsafe_pack{T}(io, source::Ref{T}, endianness, ::Type{Packed})
     # If this type cannot be subdivided, packing strategy means nothing, so
     # hand it off to the `Default` packing strategy method
     if nfields(T) == 0
@@ -297,7 +297,7 @@ no byteswapping will occur.  If `endianness` is `:LittleEndian` or
 `:BigEndian`, byteswapping will occur if the endianness of the host system
 does not match the endianness of `io`.
 """
-function pack(io::IO, source::T, endianness::Symbol = :NativeEndian) where T
+function pack{T}(io::IO, source::T, endianness::Symbol = :NativeEndian)
     r = Ref{T}(source)
     packstrat = nfields(T) == 0 ? Default : packing_strategy(T)
     unsafe_pack(io, r, endianness, packstrat)

--- a/src/StructIO.jl
+++ b/src/StructIO.jl
@@ -1,37 +1,98 @@
 __precompile__()
 module StructIO
 
-using Base: @pure
+using Base: @pure, bswap
 using Base.Meta
 using Compat
 export @io, unpack, pack, fix_endian
 
-needs_bswap(endianness) = (ENDIAN_BOM == 0x01020304) ?
-    endianness == :LittleEndian : endianness == :BigEndian
-fix_endian(x, endianness) = needs_bswap(x) ? bswap(x) : x
+"""
+    needs_bswap(endianness::Symbol)
+
+Returns `true` if the given endianness does not match the current host system.
+"""
+@pure function needs_bswap(endianness::Symbol)
+    if ENDIAN_BOM == 0x01020304
+        return endianness == :LittleEndian
+    else
+        return endianness == :BigEndian
+    end
+end
+
+# Extend bswap() for pointers to arbitrarily large objects
+@pure function bswap(ptr::Ptr{UInt8}, sz)
+    # Count from outside edge to middle
+    for i = 0:div(sz,2)
+        # Swap two mirrored bytes
+        ptr_hi = ptr + 8*(sz-i)
+        ptr_lo = ptr + 8*i
+        val_hi = unsafe_load(ptr_hi)
+        val_lo = unsafe_load(ptr_lo)
+        unsafe_store(ptr_hi, val_lo)
+        unsafe_store(ptr_lo, val_hi)
+    end
+end
+
+"""
+    fix_endian(x, endianness::Symbol)
+
+Returns a byte-swapped version of `x` if the given endianness must be swapped
+for the current host system.
+"""
+@pure function fix_endian(x, endianness::Symbol)
+    if needs_bswap(endianness)
+        return bswap(x)
+    end
+    return x
+end
 
 # Alignment traits
 @compat abstract type PackingStrategy end
 immutable Packed <: PackingStrategy; end
 immutable Default <: PackingStrategy; end
-function strategy
+
+"""
+    packing_strategy(x)
+
+Return the packing strategy for the given type, defaults to `Default`, is
+overridden by auto-generated methods for specific types from `@io` invocations.
+"""
+function packing_strategy(x)
+    return Default
 end
 
 # Sizeof computation
-round_up(offset, alignment) = offset +
-    mod(alignment - mod(offset, alignment), alignment)
+@pure function round_up(offset, alignment)
+    return offset + mod(alignment - mod(offset, alignment), alignment)
+end
 
 @pure function sizeof(T::DataType, ::Type{Default})
-    Core.sizeof(T)
+    return Core.sizeof(T)
 end
 
 @pure function sizeof(T::DataType, ::Type{Packed})
     @assert nfields(T) != 0 && isbits(T)
-    sum(sizeof, T.types)
+    return sum(sizeof, T.types)
 end
-sizeof(T::DataType) = sizeof(T, nfields(T) == 0 ? Default : strategy(T))
 
-# Generates methods for unpack!, pack!, and sizeof
+@pure function sizeof(T::DataType)
+    if nfields(T) == 0
+        return sizeof(T, Default)
+    else
+        return sizeof(T, packing_strategy(T))
+    end
+end
+
+
+"""
+    @io <type definition>
+        ...
+    end
+
+Generates `packing_strategy()` and `sizeof()` methods for the type being
+defined within the given type definition.  This enables usage of the `unpack`
+method.
+"""
 macro io(typ, annotations...)
     alignment = :align_default
     if length(annotations) == 1
@@ -40,28 +101,39 @@ macro io(typ, annotations...)
             alignment = ann
         end
     end
-    typname = typ.args[2]
-    isexpr(typname,:(<:)) && (typname = typname.args[1])
-    isexpr(typname,:curly) && (typname = typname.args[1])
-    ret = Expr(:toplevel, typ)
-    if alignment == :align_default
-        push!(ret.args, :(StructIO.strategy(::Type{$typname}) = StructIO.Default))
-    else
-        @assert alignment == :align_packed
-        push!(ret.args, :(StructIO.strategy(::Type{$typname}) = StructIO.Packed))
+    
+    # Get typename, collapsing type expressions until we get the actual type
+    T = typ.args[2]
+    if isexpr(T,:(<:))
+        T = T.args[1]
     end
-    push!(ret.args, :(Base.sizeof(::Type{$typname}) = StructIO.sizeof($typname)))
-    push!(ret.args, :(Base.sizeof(::$typname) = StructIO.sizeof($typname)))
-    esc(ret)
+    if isexpr(T,:curly)
+        T = T.args[1]
+    end
+
+    ret = Expr(:toplevel, typ)
+    strat = (alignment == :align_default ? StructIO.Default : StructIO.Packed)
+    push!(ret.args, :(StructIO.packing_strategy(::Type{$T}) = $strat))
+    push!(ret.args, :(Base.sizeof(::Type{$T}) = StructIO.sizeof($T)))
+    push!(ret.args, :(Base.sizeof(::$T) = StructIO.sizeof($T)))
+    return esc(ret)
 end
 
-function unsafe_unpack(io::IO, T::Type, target, endianness, ::Type{Default})
+"""
+    unsafe_unpack(io, T, target, endianness, ::Type{Default})
+
+Unpack an object of type `T` from `io` into `target`, byte-swapping if
+`endianness` dictates we should, assuming a `Default` packing strategy.  All
+packed structs recurse until bitstypes objects are eventually reached, at which
+point `Default` packing is the only behavior.
+"""
+function unsafe_unpack(io, T, target, endianness, ::Type{Default})
     if nfields(T) == 0
+        # If this is a primitive data type, unpack it directly
         sz = Core.sizeof(T)
         unsafe_read(io, target, sz)
         if needs_bswap(endianness)
-            # Special case small sizes, LLVM should turn this into a jump
-            # table
+            # Special case small sizes, LLVM should turn this into a jump table
             if sz == 1
             elseif sz == 2
                 ptr = Base.unsafe_convert(Ptr{UInt16}, target)
@@ -74,43 +146,58 @@ function unsafe_unpack(io::IO, T::Type, target, endianness, ::Type{Default})
                 unsafe_store!(ptr, bswap(unsafe_load(ptr)))
             else
                 for i = 0:div(sz,2)
-                    ptrhigh = Base.unsafe_convert(Ptr{UInt8}, target) + 8*(sz-i)
-                    ptrlow = Base.unsafe_convert(Ptr{UInt8}, target) + 8*i
-                    high = unsafe_load(ptrhigh)
-                    low = unsafe_load(ptrlow)
-                    unsafe_store(ptrhigh, low)
-                    unsafe_store(ptrlow, high)
+                    ptrhi = Base.unsafe_convert(Ptr{UInt8}, target) + 8*(sz-i)
+                    ptrlo = Base.unsafe_convert(Ptr{UInt8}, target) + 8*i
+                    hi = unsafe_load(ptrhi)
+                    lo = unsafe_load(ptrlo)
+                    unsafe_store(ptrhi, lo)
+                    unsafe_store(ptrlo, hi)
                 end
             end
         end
     elseif !needs_bswap(endianness)
+        # If we don't need to bswap, just read directly into `target`
         sz = Core.sizeof(T)
         unsafe_read(io, target, sz)
     else
+        # If we need to bswap, but it's not a primitive type, recurse!
         reached = 0
+        target_ptr = Base.unsafe_convert(Ptr{Void}, target)
         for i = 1:nfields(T)
+            # Unpack this field into `target` at the appropriate offset
             fT = fieldtype(T, i)
             foffs = fieldoffset(T, i)
             skip(io, reached - foffs)
-            reached = foffs
-            unsafe_unpack(io, fT,
-                Base.unsafe_convert(Ptr{Void}, target) + foffs, endianness, Default)
-            reached += Core.sizeof(fT)
+            unsafe_unpack(io, fT, target_ptr + foffs, endianness, Default)
+            reached = foffs + Core.sizeof(fT)
         end
     end
 end
 
-function unsafe_unpack(io::IO, T::Type, target, endianness, ::Type{Packed})
-    nfields(T) == 0 && return unsafe_unpack(io, T, target, endianness, Default)
+"""
+    unsafe_unpack(io, T, target, endianness, ::Type{Packed})
+
+Unpack an object of type `T` from `io` into `target`, byte-swapping if
+`endianness` dictates we should, assuming a `Packed` packing strategy.
+"""
+function unsafe_unpack(io, T, target, endianness, ::Type{Packed})
+    # If this type cannot be subdivided, unpack directly
+    if nfields(T) == 0
+        return unsafe_unpack(io, T, target, endianness, Default)
+    end
+
+    # Otherwise, iterate over the fields, unpacking each into `target`
+    target_ptr = Base.unsafe_convert(Ptr{Void}, target)
     for i = 1:nfields(T)
+        # Unpack this field into `target` at the appropriate offset
         fT = fieldtype(T, i)
-        unsafe_unpack(io, fT,
-            Base.unsafe_convert(Ptr{Void}, target) + fieldoffset(T, i), endianness, Packed)
+        target_i = target_ptr + fieldoffset(T, i)
+        unsafe_unpack(io, fT, target_i, endianness, Packed)
     end
 end
 
 """
-unpack(io::IO, T::Type, endianness::Symbol = :NativeEndian)
+    unpack(io::IO, T::Type, endianness::Symbol = :NativeEndian)
 
 Given an input `io`, unpack type `T`, byte-swapping according to the given
 `endianness` of `io`. If `endianness` is `:NativeEndian` (the default), no
@@ -119,9 +206,13 @@ byteswapping will occur of the endianness of the currently running host does
 not match the endianness of `io`.
 """
 function unpack(io::IO, T::Type, endianness::Symbol = :NativeEndian)
+    # Create a `Ref{}` pointing to type T, we'll unpack into that
     r = Ref{T}()
-    unsafe_unpack(io, T, r, endianness, nfields(T) == 0 ? Default : strategy(T))
-    r[]
+    packstrat = nfields(T) == 0 ? Default : packing_strategy(T)
+    unsafe_unpack(io, T, r, endianness, packstrat)
+
+    # De-reference `r` and return its unpacked contents
+    return r[]
 end
 
 end # module

--- a/src/StructIO.jl
+++ b/src/StructIO.jl
@@ -194,8 +194,8 @@ end
     unsafe_pack(io, source, endianness, ::Type{Packed/Default})
 
 Pack `source` into `io`, byte-swapping if `endianness` dictates we should.  The
-last argument is a packing strategy, used to determine the layout of the data in
-memory.  All `Packed` objects recurse until bitstypes objects are eventually
+last argument is a packing strategy, used to determine the layout of the data
+in memory.  All `Packed` objects recurse until bitstypes objects are eventually
 reached, at which point `Default` packing is identical to `Packed` behavior.
 """
 function unsafe_pack(io, source::Ref{T}, endianness, ::Type{Default}) where T

--- a/src/StructIO.jl
+++ b/src/StructIO.jl
@@ -1,118 +1,118 @@
 __precompile__()
 module StructIO
 
-    using Base: @pure
-    using Base.Meta
-    using Compat
-    export @io, unpack, pack, fix_endian
+using Base: @pure
+using Base.Meta
+using Compat
+export @io, unpack, pack, fix_endian
 
-    needs_bswap(endianness) = (ENDIAN_BOM == 0x01020304) ?
-        endianness == :LittleEndian : endianness == :BigEndian
-    fix_endian(x, endianness) = needs_bswap(x) ? bswap(x) : x
+needs_bswap(endianness) = (ENDIAN_BOM == 0x01020304) ?
+    endianness == :LittleEndian : endianness == :BigEndian
+fix_endian(x, endianness) = needs_bswap(x) ? bswap(x) : x
 
-    # Alignment traits
-    @compat abstract type PackingStrategy end
-    immutable Packed <: PackingStrategy; end
-    immutable Default <: PackingStrategy; end
-    function strategy
-    end
+# Alignment traits
+@compat abstract type PackingStrategy end
+immutable Packed <: PackingStrategy; end
+immutable Default <: PackingStrategy; end
+function strategy
+end
 
-    # Sizeof computation
-    round_up(offset, alignment) = offset +
-        mod(alignment - mod(offset, alignment), alignment)
+# Sizeof computation
+round_up(offset, alignment) = offset +
+    mod(alignment - mod(offset, alignment), alignment)
 
-    @pure function sizeof(T::DataType, ::Type{Default})
-        Core.sizeof(T)
-    end
+@pure function sizeof(T::DataType, ::Type{Default})
+    Core.sizeof(T)
+end
 
-    @pure function sizeof(T::DataType, ::Type{Packed})
-        @assert nfields(T) != 0 && isbits(T)
-        sum(sizeof, T.types)
-    end
-    sizeof(T::DataType) = sizeof(T, nfields(T) == 0 ? Default : strategy(T))
+@pure function sizeof(T::DataType, ::Type{Packed})
+    @assert nfields(T) != 0 && isbits(T)
+    sum(sizeof, T.types)
+end
+sizeof(T::DataType) = sizeof(T, nfields(T) == 0 ? Default : strategy(T))
 
-    # Generates methods for unpack!, pack!, and sizeof
-    macro io(typ, annotations...)
-        alignment = :align_default
-        if length(annotations) == 1
-            ann = annotations[1]
-            if isa(ann, Symbol) || haskey(alignments, ann)
-                alignment = ann
-            end
+# Generates methods for unpack!, pack!, and sizeof
+macro io(typ, annotations...)
+    alignment = :align_default
+    if length(annotations) == 1
+        ann = annotations[1]
+        if isa(ann, Symbol) || haskey(alignments, ann)
+            alignment = ann
         end
-        typname = typ.args[2]
-        isexpr(typname,:(<:)) && (typname = typname.args[1])
-        isexpr(typname,:curly) && (typname = typname.args[1])
-        ret = Expr(:toplevel, typ)
-        if alignment == :align_default
-            push!(ret.args, :(StructIO.strategy(::Type{$typname}) = StructIO.Default))
-        else
-            @assert alignment == :align_packed
-            push!(ret.args, :(StructIO.strategy(::Type{$typname}) = StructIO.Packed))
-        end
-        push!(ret.args, :(Base.sizeof(::Type{$typname}) = StructIO.sizeof($typname)))
-        push!(ret.args, :(Base.sizeof(::$typname) = StructIO.sizeof($typname)))
-        esc(ret)
     end
+    typname = typ.args[2]
+    isexpr(typname,:(<:)) && (typname = typname.args[1])
+    isexpr(typname,:curly) && (typname = typname.args[1])
+    ret = Expr(:toplevel, typ)
+    if alignment == :align_default
+        push!(ret.args, :(StructIO.strategy(::Type{$typname}) = StructIO.Default))
+    else
+        @assert alignment == :align_packed
+        push!(ret.args, :(StructIO.strategy(::Type{$typname}) = StructIO.Packed))
+    end
+    push!(ret.args, :(Base.sizeof(::Type{$typname}) = StructIO.sizeof($typname)))
+    push!(ret.args, :(Base.sizeof(::$typname) = StructIO.sizeof($typname)))
+    esc(ret)
+end
 
-    function unsafe_unpack(io::IO, T::Type, target, endianness, ::Type{Default})
-        if nfields(T) == 0
-            sz = Core.sizeof(T)
-            unsafe_read(io, target, sz)
-            if needs_bswap(endianness)
-                # Special case small sizes, LLVM should turn this into a jump
-                # table
-                if sz == 1
-                elseif sz == 2
-                    ptr = Base.unsafe_convert(Ptr{UInt16}, target)
-                    unsafe_store!(ptr, bswap(unsafe_load(ptr)))
-                elseif sz == 4
-                    ptr = Base.unsafe_convert(Ptr{UInt32}, target)
-                    unsafe_store!(ptr, bswap(unsafe_load(ptr)))
-                elseif sz == 8
-                    ptr = Base.unsafe_convert(Ptr{UInt64}, target)
-                    unsafe_store!(ptr, bswap(unsafe_load(ptr)))
-                else
-                    for i = 0:div(sz,2)
-                        ptrhigh = Base.unsafe_convert(Ptr{UInt8}, target) + 8*(sz-i)
-                        ptrlow = Base.unsafe_convert(Ptr{UInt8}, target) + 8*i
-                        high = unsafe_load(ptrhigh)
-                        low = unsafe_load(ptrlow)
-                        unsafe_store(ptrhigh, low)
-                        unsafe_store(ptrlow, high)
-                    end
+function unsafe_unpack(io::IO, T::Type, target, endianness, ::Type{Default})
+    if nfields(T) == 0
+        sz = Core.sizeof(T)
+        unsafe_read(io, target, sz)
+        if needs_bswap(endianness)
+            # Special case small sizes, LLVM should turn this into a jump
+            # table
+            if sz == 1
+            elseif sz == 2
+                ptr = Base.unsafe_convert(Ptr{UInt16}, target)
+                unsafe_store!(ptr, bswap(unsafe_load(ptr)))
+            elseif sz == 4
+                ptr = Base.unsafe_convert(Ptr{UInt32}, target)
+                unsafe_store!(ptr, bswap(unsafe_load(ptr)))
+            elseif sz == 8
+                ptr = Base.unsafe_convert(Ptr{UInt64}, target)
+                unsafe_store!(ptr, bswap(unsafe_load(ptr)))
+            else
+                for i = 0:div(sz,2)
+                    ptrhigh = Base.unsafe_convert(Ptr{UInt8}, target) + 8*(sz-i)
+                    ptrlow = Base.unsafe_convert(Ptr{UInt8}, target) + 8*i
+                    high = unsafe_load(ptrhigh)
+                    low = unsafe_load(ptrlow)
+                    unsafe_store(ptrhigh, low)
+                    unsafe_store(ptrlow, high)
                 end
             end
-        elseif !needs_bswap(endianness)
-            sz = Core.sizeof(T)
-            unsafe_read(io, target, sz)
-        else
-            reached = 0
-            for i = 1:nfields(T)
-                fT = fieldtype(T, i)
-                foffs = fieldoffset(T, i)
-                skip(io, reached - foffs)
-                reached = foffs
-                unsafe_unpack(io, fT,
-                    Base.unsafe_convert(Ptr{Void}, target) + foffs, endianness, Default)
-                reached += Core.sizeof(fT)
-            end
         end
-    end
-
-    function unsafe_unpack(io::IO, T::Type, target, endianness, ::Type{Packed})
-        nfields(T) == 0 && return unsafe_unpack(io, T, target, endianness, Default)
+    elseif !needs_bswap(endianness)
+        sz = Core.sizeof(T)
+        unsafe_read(io, target, sz)
+    else
+        reached = 0
         for i = 1:nfields(T)
             fT = fieldtype(T, i)
+            foffs = fieldoffset(T, i)
+            skip(io, reached - foffs)
+            reached = foffs
             unsafe_unpack(io, fT,
-                Base.unsafe_convert(Ptr{Void}, target) + fieldoffset(T, i), endianness, Packed)
+                Base.unsafe_convert(Ptr{Void}, target) + foffs, endianness, Default)
+            reached += Core.sizeof(fT)
         end
     end
+end
 
-    function unpack(io::IO, T::Type, endianness = :NativeEndian)
-        r = Ref{T}()
-        unsafe_unpack(io, T, r, endianness, nfields(T) == 0 ? Default : strategy(T))
-        r[]
+function unsafe_unpack(io::IO, T::Type, target, endianness, ::Type{Packed})
+    nfields(T) == 0 && return unsafe_unpack(io, T, target, endianness, Default)
+    for i = 1:nfields(T)
+        fT = fieldtype(T, i)
+        unsafe_unpack(io, fT,
+            Base.unsafe_convert(Ptr{Void}, target) + fieldoffset(T, i), endianness, Packed)
     end
+end
+
+function unpack(io::IO, T::Type, endianness = :NativeEndian)
+    r = Ref{T}()
+    unsafe_unpack(io, T, r, endianness, nfields(T) == 0 ? Default : strategy(T))
+    r[]
+end
 
 end # module

--- a/src/StructIO.jl
+++ b/src/StructIO.jl
@@ -1,4 +1,4 @@
-VERSION >= v"0.4.0-dev+6641" && __precompile__()
+__precompile__()
 module StructIO
 
     using Base: @pure

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -7,12 +7,6 @@ using Base.Test
     y::UInt
 end
 
-buf = IOBuffer()
-write(buf, UInt(1))
-write(buf, UInt(2))
-seekstart(buf)
-@test unpack(buf, TwoUInts) == TwoUInts(1,2)
-
 @compat abstract type SomeAbstractType end
 @io immutable SomeConcreteType <: SomeAbstractType
     A::UInt32
@@ -25,4 +19,12 @@ end align_packed
     A::S
     B::T
     C::T
+end
+
+@testset "unpack()" begin
+    buf = IOBuffer()
+    write(buf, UInt(1))
+    write(buf, UInt(2))
+    seekstart(buf)
+    @test unpack(buf, TwoUInts) == TwoUInts(1,2)
 end


### PR DESCRIPTION
Large internal cleanup

* Adds a `pack()` method, to mirror `unpack()`.

* Eliminates the `StructIO.sizeof()/Core.sizeof()` ambiguity, opting instead for a different name for that method, `packed_size()`.

* Adds a test suite and fixes some corner case bugs that were found in the original code.

* Adds documentation for everything exported, and even some things that were not exported.

@Keno what do you think of these?  This is the deepest level of a decent yak shave I embarked upon while rewriting `ObjFileBase`.  :P