### PR TITLE
Allow `@io`'ed types to be documented

### DIFF
--- a/src/StructIO.jl
+++ b/src/StructIO.jl
@@ -133,7 +133,7 @@ macro io(typ, annotations...)
         T = T.args[1]
     end
 
-    ret = Expr(:toplevel, typ)
+    ret = Expr(:toplevel, :(Base.@__doc__ $(typ)))
     strat = (alignment == :align_default ? StructIO.Default : StructIO.Packed)
     push!(ret.args, :(StructIO.packing_strategy(::Type{$T}) = $strat))
     return esc(ret)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -27,6 +27,10 @@ end align_packed
     B::ConcreteType
 end
 
+# Also test documenting a type
+"""
+This is a docstring
+"""
 @io immutable ParametricType{S,T}
     A::S
     B::T
@@ -126,4 +130,8 @@ end
             @test unpack(buf, NT) == nt
         end
     end
+end
+
+@testset "Documentation" begin
+    @test string(@doc ParametricType) == "This is a docstring\n"
 end


### PR DESCRIPTION
Allows the attachment of docstrings to a type that has been `@io`'ed.