### PR TITLE
Ensure that packing of parametric types works properly

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,6 @@ language: julia
 os:
   - linux
 julia:
-  - 0.5
   - 0.6
   - nightly
 notifications:

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![StructIO](http://pkg.julialang.org/badges/StructIO_0.5.svg)](http://pkg.julialang.org/?pkg=StructIO)
 [![Build Status](https://travis-ci.org/Keno/StructIO.jl.svg?branch=master)](https://travis-ci.org/Keno/StructIO.jl)
 
-Generates IO methods (`sizeof`, `pack`, `unpack`) from structure definitions.
+Generates IO methods (`pack`, `unpack`) from structure definitions.  Also defines `packed_sizeof` to give the on-disk size of a packed structure, which is smaller than `sizeof` would give, if the struct is marked as `align_packed`.
 
 # Example usage
 ```julia

--- a/REQUIRE
+++ b/REQUIRE
@@ -1,2 +1,2 @@
-julia 0.5
+julia 0.6
 Compat 0.17.0

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -27,6 +27,11 @@ end align_packed
     B::ConcreteType
 end
 
+@io immutable PackedParametricType{T}
+    x::T
+    y::T
+end align_packed
+
 # Also test documenting a type
 """
 This is a docstring
@@ -130,6 +135,16 @@ end
             @test unpack(buf, NT) == nt
         end
     end
+end
+
+@testset "packed_sizeof()" begin
+    @test packed_sizeof(TwoUInts) == 2*sizeof(UInt)
+    @test packed_sizeof(ConcreteType) == 1 + 2 + 4 + 16
+    @test packed_sizeof(PackedNestedType) == 2*packed_sizeof(ConcreteType)
+    @test packed_sizeof(PackedParametricType{UInt8}) == 2
+    @test packed_sizeof(PackedParametricType{UInt32}) == 8
+    const psCT = packed_sizeof(ConcreteType)
+    @test packed_sizeof(PackedParametricType{ConcreteType}) == 2*psCT
 end
 
 @testset "Documentation" begin


### PR DESCRIPTION
Also rename `packed_size()` to `packed_sizeof()` for greater consistency.

@Keno I think this is the last change I'll need to make in a while; shall we cut a new release?