### PR TITLE
macro hygiene: don't assume StructIO is in scope in io macro

### DIFF
--- a/src/StructIO.jl
+++ b/src/StructIO.jl
@@ -138,7 +138,7 @@ macro io(typ, annotations...)
 
     ret = Expr(:toplevel, :(Base.@__doc__ $(typ)))
     strat = (alignment == :align_default ? StructIO.Default : StructIO.Packed)
-    push!(ret.args, :(StructIO.packing_strategy(::Type{T}) where {T <: $T} = $strat))
+    push!(ret.args, :($packing_strategy(::Type{T}) where {T <: $T} = $strat))
     return esc(ret)
 end
 

--- a/src/StructIO.jl
+++ b/src/StructIO.jl
@@ -137,8 +137,9 @@ macro io(typ, annotations...)
     end
 
     ret = Expr(:toplevel, :(Base.@__doc__ $(typ)))
+    push!(ret.args, :(import StructIO)) # issue #24
     strat = (alignment == :align_default ? StructIO.Default : StructIO.Packed)
-    push!(ret.args, :($packing_strategy(::Type{T}) where {T <: $T} = $strat))
+    push!(ret.args, :(StructIO.packing_strategy(::Type{T}) where {T <: $T} = $strat))
     return esc(ret)
 end
 

--- a/src/StructIO.jl
+++ b/src/StructIO.jl
@@ -137,9 +137,8 @@ macro io(typ, annotations...)
     end
 
     ret = Expr(:toplevel, :(Base.@__doc__ $(typ)))
-    push!(ret.args, :(import StructIO)) # issue #24
     strat = (alignment == :align_default ? StructIO.Default : StructIO.Packed)
-    push!(ret.args, :(StructIO.packing_strategy(::Type{T}) where {T <: $T} = $strat))
+    push!(ret.args, :($StructIO.packing_strategy(::Type{T}) where {T <: $T} = $strat))
     return esc(ret)
 end
 


### PR DESCRIPTION
Should fix #24.