### PR TITLE
fix nightly docstring test failure

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -7,6 +7,7 @@ julia = "1"
 
 [extras]
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
+REPL = "3fa0cd96-eef1-5676-8a61-b3b8758bbffb"
 
 [targets]
-test = ["Test"]
+test = ["Test", "REPL"]

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -164,5 +164,5 @@ end
 end
 
 @testset "Documentation" begin
-    @test String(@doc ParametricType) == "This is a docstring\n"
+    @test string(@doc ParametricType) == "This is a docstring\n"
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,5 +1,5 @@
 using StructIO
-using Test
+using Test, REPL
 
 # First, exercise the `@io` macro a bit, to ensure it can handle different
 # kinds of type declarations

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,5 +1,6 @@
 using StructIO
-using Test, REPL
+using Test
+import REPL # needed for docstring-string conversion
 
 # First, exercise the `@io` macro a bit, to ensure it can handle different
 # kinds of type declarations

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,6 +1,6 @@
 using StructIO
 using Test
-import REPL # needed for docstring-string conversion
+import REPL # needed for docstrings on nightly: julia#55438
 
 # First, exercise the `@io` macro a bit, to ensure it can handle different
 # kinds of type declarations

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -164,5 +164,5 @@ end
 end
 
 @testset "Documentation" begin
-    @test string(@doc ParametricType) == "This is a docstring\n"
+    @test String(@doc ParametricType) == "This is a docstring\n"
 end


### PR DESCRIPTION
This hopefully fixes a nightly failure I'm seeing on #29:
```
 Documentation: Test Failed at /home/runner/work/StructIO.jl/StructIO.jl/test/runtests.jl:167
  Expression: string(#= /home/runner/work/StructIO.jl/StructIO.jl/test/runtests.jl:167 =# @doc(ParametricType)) == "This is a docstring\n"
   Evaluated: "Base.Docs.DocStr(svec(\"This is a docstring\\n\"), nothing, Dict{Symbol, Any}(:typesig => Union{}, :module => Main, :linenumber => 35, :binding => ParametricType, :path => \"/home/runner/work/StructIO.jl/StructIO.jl/test/runtests.jl\", :fields => Dict{Symbol, Any}()))" == "This is a docstring\n"
```
Apparently, on nightly, `@doc foo` is returning a `DocStr` instance, which but `string(@doc foo)` no longer extracts the underlying string?  Something should probably be fixed in Julia itself, but I'm hoping to find a workaround for now.