### PR TITLE
Offset pack

### DIFF
--- a/src/StructIO.jl
+++ b/src/StructIO.jl
@@ -77,7 +77,7 @@ end
 @pure function packed_sizeof(T::DataType, ::Type{Offset})
     @assert fieldcount(T) != 0 && isbitstype(T)
     f_offsets = StructIO.stream_offset.(T, 1:fieldcount(T))
-    max_offset,idx_max = findmax(identity, f_offsets)
+    max_offset,idx_max = findmax(f_offsets)
     
     return max_offset + packed_sizeof(T.types[idx_max])
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -203,7 +203,7 @@ end
 	                           z::Int ~ 6
 	                       end align_offset)
     #
-	@test_throws ArgumentError macroexpand(@__MODULE__, missing_annotation)
+	@test_throws Exception macroexpand(@__MODULE__, missing_annotation)
     @test packed_sizeof(RawData) == packed_sizeof(OffsetStruct)
 	for endian in [:LittleEndian, :BigEndian]
         buf = IOBuffer()


### PR DESCRIPTION
This PR adds the ability to unpack a binary buffer while skipping some parts of it. The usage may be illustrated by this fragment from `runtests.jl`:
```julia
@io struct RawData
    A::UInt32       # offset 0
    dummy_1::UInt16 # offset 4
    B::UInt16       # offset 6
    dummy_2::UInt32 # offset 8
    C::UInt128      # offset 12
    dummy_3::UInt16 # offset 28
    dummy_4::UInt32 # offset 30
    D::UInt8        # offset 34
end align_packed

@io struct OffsetStruct
    A::UInt32  ~ 0
    C::UInt128 ~ 12
    B::UInt16  ~ 6
    D::UInt8   ~ 34
end align_offset

A,B,C,D = 1,2,3,4
raw_data = RawData(UInt32(A),0xBEEF,UInt16(B),0xDEADBEEF,UInt128(C),
                                      0xBEEF, 0xDEADBEEF, UInt8(D));
pack(buf, raw_data, endian)
seekstart(buf)
@test unpack(buf, OffsetStruct, endian) == OffsetStruct(A, C, B, D)
```

The `pack()` method for `align_offset` packing strategy is not yet implemented, because there are several ways to go about it, and I could use some discussion. If there's an interest in merging this PR, I'll fill the gaps.