### PR TITLE
Enable packing and unpacking structures with user-specified gaps between fields

### DIFF
--- a/src/StructIO.jl
+++ b/src/StructIO.jl
@@ -70,7 +70,7 @@ end
 
 @pure function packed_sizeof(T::DataType, ::Type{Packed})
     @assert fieldcount(T) != 0 && isbitstype(T)
-    return sum(packed_sizeof, T.types)
+    return sum(packed_sizeof, T.types) + sum(field_gaps(T))
 end
 
 @pure function packed_sizeof(T::DataType)
@@ -102,7 +102,6 @@ Return the size (in bytes) of a field within `T` in memory
         return fieldoffset(T, field_idx + 1) - offset
     end
 end
-
 
 """
     @io <type definition>
@@ -136,11 +135,20 @@ macro io(typ, annotations...)
         T = T.args[1]
     end
 
+    if alignment == :align_packed
+        gap_values =  strip_gap_nodes!(typ)
+    end
+    
     ret = Expr(:toplevel, :(Base.@__doc__ $(typ)))
     strat = (alignment == :align_default ? StructIO.Default : StructIO.Packed)
     push!(ret.args, :($StructIO.packing_strategy(::Type{T}) where {T <: $T} = $strat))
+    if strat == Packed
+         push!(ret.args, :($StructIO.field_gaps(::Type{T})  where {T <: $T} = $gap_values))
+    end
+    
     return esc(ret)
 end
+field_gaps(::Type{T}) where T = UInt[]
 
 """
     unsafe_unpack(io, T, target, endianness, ::Type{Default})
@@ -242,7 +250,7 @@ function unsafe_pack(io, source::Ref{T}, endianness, ::Type{Default}) where {T}
 end
 
 # `Packed` packing strategy override for `unsafe_unpack`
-function unsafe_unpack(io, T, target, endianness, ::Type{Packed})
+function unsafe_unpack(io, T, target, endianness, ::Type{Packed}; gaps=field_gaps(T))
     # If this type cannot be subdivided, packing strategy means nothing, so
     # hand it off to the `Default` packing strategy method
     if fieldcount(T) == 0
@@ -255,12 +263,15 @@ function unsafe_unpack(io, T, target, endianness, ::Type{Packed})
         # Unpack this field into `target` at the appropriate offset
         fT = fieldtype(T, i)
         target_i = target_ptr + fieldoffset(T, i)
+        isempty(gaps) || skip(io, gaps[i])
         unsafe_unpack(io, fT, target_i, endianness, Packed)
     end
 end
 
 # `Packed` packing strategy override for `unsafe_pack`
-function unsafe_pack(io, source::Ref{T}, endianness, ::Type{Packed}) where {T}
+function unsafe_pack(
+    io, source::Ref{T}, endianness, ::Type{Packed}; gaps=field_gaps(T)
+    ) where {T}
     # If this type cannot be subdivided, packing strategy means nothing, so
     # hand it off to the `Default` packing strategy method
     if fieldcount(T) == 0
@@ -272,6 +283,7 @@ function unsafe_pack(io, source::Ref{T}, endianness, ::Type{Packed}) where {T}
         # Unpack this field into `target` at the appropriate offset
         fT = fieldtype(T, i)
         f = Ref{fT}(getfield(source[], fieldname(T, i)))
+        isempty(gaps) || skip(io, gaps[i])
         unsafe_pack(io, f, endianness, Packed)
     end
 end
@@ -310,5 +322,49 @@ function pack(io::IO, source::T, endianness::Symbol = :NativeEndian) where {T}
     unsafe_pack(io, r, endianness, packstrat)
     return nothing
 end
+
+function strip_gap_nodes!(strct_expr::Expr)
+    @assert strct_expr.head == :struct
+    strct_nodes = strct_expr.args[3].args
+    K = length(strct_nodes)
+    gap_locations = UInt[]
+    # accumulator, in case several gap specifications occur in unbroken succession
+    gap_value = zero(UInt)
+    # gaps before structure fields
+    field_gap_values = UInt[]
+    for k in 1:K
+        f = strct_nodes[k]
+        !isa(f, LineNumberNode) || continue
+        if f.head === :(::)
+            # collect positions of gap nodes, when encountering a structure
+            # field, 
+            if f.args[1] === :_ 
+                if isa(f.args[2], Integer) && f.args[2] >= 0
+                    push!(gap_locations, k)
+                    gap_value += UInt(f.args[2])
+                else
+                    error("incorrect gap specification: $f")
+                end
+            elseif isa(f.args[1], Symbol)
+                
+                push!(field_gap_values, gap_value)
+                gap_value = zero(UInt)
+            else
+                error("unsupported structure field specificaion: $f")
+            end
+        end
+    end
+    if all(iszero, field_gap_values)
+        field_gap_values = UInt[]
+    end
+    # remove gap specifications from the expression tree
+    for k in length(gap_locations):-1:1
+        deleteat!(strct_nodes, gap_locations[k])
+    end
+    strct_expr.args[3].args = strct_nodes
+
+    return field_gap_values
+end
+
 
 end # module

--- a/src/StructIO.jl
+++ b/src/StructIO.jl
@@ -266,6 +266,7 @@ function unsafe_unpack(io, T, target, endianness, ::Type{Packed}; gaps=field_gap
         isempty(gaps) || skip(io, gaps[i])
         unsafe_unpack(io, fT, target_i, endianness, Packed)
     end
+    isempty(gaps) || skip(io, gaps[fieldcount(T) + 1])
 end
 
 # `Packed` packing strategy override for `unsafe_pack`
@@ -286,6 +287,7 @@ function unsafe_pack(
         isempty(gaps) || skip(io, gaps[i])
         unsafe_pack(io, f, endianness, Packed)
     end
+    isempty(gaps) || skip(io, gaps[fieldcount(T) + 1])
 end
 
 """
@@ -337,7 +339,7 @@ function strip_gap_nodes!(strct_expr::Expr)
         !isa(f, LineNumberNode) || continue
         if f.head === :(::)
             # collect positions of gap nodes, when encountering a structure
-            # field, 
+            # field, store the accumulated gap and reset the accumulator
             if f.args[1] === :_ 
                 if isa(f.args[2], Integer) && f.args[2] >= 0
                     push!(gap_locations, k)
@@ -354,6 +356,8 @@ function strip_gap_nodes!(strct_expr::Expr)
             end
         end
     end
+    # do not neglect the gap after the last field
+    push!(field_gap_values, gap_value)
     if all(iszero, field_gap_values)
         field_gap_values = UInt[]
     end

--- a/src/StructIO.jl
+++ b/src/StructIO.jl
@@ -336,8 +336,7 @@ function strip_gap_nodes!(strct_expr::Expr)
     field_gap_values = UInt[]
     for k in 1:K
         f = strct_nodes[k]
-        !isa(f, LineNumberNode) || continue
-        if f.head === :(::)
+        if Meta.isexpr(f, :(::))
             # collect positions of gap nodes, when encountering a structure
             # field, store the accumulated gap and reset the accumulator
             if f.args[1] === :_ 
@@ -352,7 +351,7 @@ function strip_gap_nodes!(strct_expr::Expr)
                 push!(field_gap_values, gap_value)
                 gap_value = zero(UInt)
             else
-                error("unsupported structure field specificaion: $f")
+                error("unsupported structure field specification: $f")
             end
         end
     end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -43,18 +43,19 @@ end align_packed
     dummy_4::UInt16
     dummy_5::UInt64
     D::UInt8
+    dummy_6::UInt8
 end align_packed
 
 @io struct GappedStruct
     A::UInt32
-    _::1
-    _::2
+    _::3
     B::UInt16
     _::4
     C::UInt128
     _::2
     _::8
     _D::UInt8
+    _::1
 end align_packed
 
 
@@ -197,20 +198,22 @@ end
 @testset "Struct with gaps" begin
     A,B,C,D = 1,2,3,4
     gapped_struct =  GappedStruct(A, B, C, D)
-    raw_data = RawData(UInt32(A),0xBE, 0xBEEF,UInt16(B),0xDEADBEEF,UInt128(C),
-                       0xBEEF, 0xDEADBEEFDEADBEEF, UInt8(D));
-    unpacked_raw_data = RawData(UInt32(A),0x00, 0x0000,UInt16(B),0x00000000,UInt128(C),
-                       0x0000, 0x0000000000000000, UInt8(D));
+    raw_data = RawData(A, 0xBE, 0xBEEF, B, 0xDEADBEEF, C, 0xBEEF, 0xDEADBEEFDEADBEEF,
+                       D, 0xBE);
+    unpacked_raw_data = RawData(A, 0, 0, B, 0, C, 0, 0, D, 0);
     #
+    @test all(StructIO.field_gaps(GappedStruct) .== [0, 3, 4, 10, 1])
     @test packed_sizeof(RawData) == packed_sizeof(GappedStruct)
 	for endian in [:LittleEndian, :BigEndian]
         buf = IOBuffer()
         pack(buf, raw_data, endian)
         seekstart(buf)
         @test unpack(buf, GappedStruct, endian) == gapped_struct
+        @test eof(buf)
         #
         buf = IOBuffer(zeros(UInt8, packed_sizeof(GappedStruct)), read=true, write=true)
         pack(buf, gapped_struct, endian)
+        @test eof(buf)
         seekstart(buf)
         @test unpack(buf, GappedStruct, endian) == gapped_struct
         seekstart(buf)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -32,6 +32,32 @@ end
     y::T
 end align_packed
 
+# Structs with gaps
+@io struct RawData
+    A::UInt32
+    dummy_1::UInt8
+    dummy_2::UInt16
+    B::UInt16
+    dummy_3::UInt32
+    C::UInt128
+    dummy_4::UInt16
+    dummy_5::UInt64
+    D::UInt8
+end align_packed
+
+@io struct GappedStruct
+    A::UInt32
+    _::1
+    _::2
+    B::UInt16
+    _::4
+    C::UInt128
+    _::2
+    _::8
+    _D::UInt8
+end align_packed
+
+
 # Also test documenting a type
 """
 This is a docstring
@@ -166,4 +192,28 @@ end
 
 @testset "Documentation" begin
     @test string(@doc ParametricType) == "This is a docstring\n"
+end
+
+@testset "Struct with gaps" begin
+    A,B,C,D = 1,2,3,4
+    gapped_struct =  GappedStruct(A, B, C, D)
+    raw_data = RawData(UInt32(A),0xBE, 0xBEEF,UInt16(B),0xDEADBEEF,UInt128(C),
+                       0xBEEF, 0xDEADBEEFDEADBEEF, UInt8(D));
+    unpacked_raw_data = RawData(UInt32(A),0x00, 0x0000,UInt16(B),0x00000000,UInt128(C),
+                       0x0000, 0x0000000000000000, UInt8(D));
+    #
+    @test packed_sizeof(RawData) == packed_sizeof(GappedStruct)
+	for endian in [:LittleEndian, :BigEndian]
+        buf = IOBuffer()
+        pack(buf, raw_data, endian)
+        seekstart(buf)
+        @test unpack(buf, GappedStruct, endian) == gapped_struct
+        #
+        buf = IOBuffer(zeros(UInt8, packed_sizeof(GappedStruct)), read=true, write=true)
+        pack(buf, gapped_struct, endian)
+        seekstart(buf)
+        @test unpack(buf, GappedStruct, endian) == gapped_struct
+        seekstart(buf)
+        @test unpack(buf, RawData, endian) == unpacked_raw_data
+    end
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -216,6 +216,7 @@ end
         @test eof(buf)
         seekstart(buf)
         @test unpack(buf, GappedStruct, endian) == gapped_struct
+        @test eof(buf)
         seekstart(buf)
         @test unpack(buf, RawData, endian) == unpacked_raw_data
     end


### PR DESCRIPTION
Following the discussion in #34,  I implemented the suggested syntax for packing to/unpacking from a binary buffer while skipping some parts of it. The usage may be illustrated by this fragment from `runtests.jl`:

```julia
@io struct RawData
    A::UInt32
    dummy_1::UInt8
    dummy_2::UInt16
    B::UInt16
    dummy_3::UInt32
    C::UInt128
    dummy_4::UInt16
    dummy_5::UInt64
    D::UInt8
end align_packed

@io struct GappedStruct
    A::UInt32
    _::3
    B::UInt16
    _::4
    C::UInt128
    _::2
    _::8
    _D::UInt8
end align_packed

A,B,C,D = 1,2,3,4
gapped_struct =  GappedStruct(A, B, C, D)
raw_data = RawData(A, 0xBE, 0xBEEF, B, 0xDEADBEEF, C,  0xBEEF, 0xDEADBEEFDEADBEEF,  D);
unpacked_raw_data = RawData(A, 0, 0, B, 0, C, 0, 0, D);

buf = IOBuffer()
pack(buf, raw_data)
seekstart(buf)
@test unpack(buf, GappedStruct) == gapped_struct
buf = IOBuffer(zeros(UInt8, packed_sizeof(GappedStruct)), read=true, write=true)
pack(buf, gapped_struct)
seekstart(buf)
@test unpack(buf, GappedStruct) == gapped_struct
seekstart(buf)
@test unpack(buf, RawData) == unpacked_raw_data
```

